### PR TITLE
Fixing elided_lifetimes_in_path warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 // Rustc lints
 #![forbid(unsafe_code)]
 #![warn(elided_lifetimes_in_associated_constant)]
-#![warn(elided_lifetimes_in_path)]
 #![warn(elided_lifetimes_in_paths)]
 #![warn(future_incompatible)]
 #![warn(keyword_idents)]


### PR DESCRIPTION
Rust gives a warning that this is removed.